### PR TITLE
chore(lexical-editor): add license & author

### DIFF
--- a/packages/lexical-editor/package.json
+++ b/packages/lexical-editor/package.json
@@ -1,5 +1,7 @@
 {
   "name": "@twreporter/lexical-editor",
+  "author": "twreporter <developer@twreporter.org>",
+  "license": "MIT",
   "version": "0.2.0-beta.2",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
# Issue
- fix npm publish warning: `lerna WARN ENOLICENSE Package @twreporter/lexical-editor is missing a license.`