### PR TITLE
fix(react-typescript-components): dropdown menu text align

### DIFF
--- a/packages/react-typescript-components/src/dropdown-menu/dropdown-menu-item/index.tsx
+++ b/packages/react-typescript-components/src/dropdown-menu/dropdown-menu-item/index.tsx
@@ -14,7 +14,7 @@ const DropdownMenuItem: FC<{
   return (
     <div
       className={clsx(
-        'py-[8px] pl-[48px] pr-[32px] cursor-pointer',
+        'py-[8px] pl-[48px] pr-[32px] cursor-pointer text-left',
         color,
         hoverBgColor,
         activeBgColor


### PR DESCRIPTION
# Issue
[[CMS搬遷]前台 Header Menu 跑版](https://www.notion.so/twreporter/CMS-Header-Menu-2998dbdca93280f386a7c8349b7ee2ac?source=copy_link)

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
