### PR TITLE
fix(lexical-editor): add class for storytelling & disable small screen preview

### DIFF
--- a/packages/lexical-editor/src/react/editor/RichEditor.tsx
+++ b/packages/lexical-editor/src/react/editor/RichEditor.tsx
@@ -48,8 +48,9 @@ export default function Editor({
   const enableImage = config.features?.image !== false
   const enableEmbeddedCode = config.features?.embeddedCode !== false
 
+  // editor-fullscreen-scroller is for storytelling components
   return (
-    <div className={`editor-shell ${isFullscreen ? 'fullscreen' : ''}`}>
+    <div className={`editor-shell ${isFullscreen ? 'fullscreen editor-fullscreen-scroller' : ''}`}>
       {showToolbar ? (
         <ToolbarPlugin
           editor={editor}

--- a/packages/lexical-editor/src/react/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-editor/src/react/plugins/ToolbarPlugin/index.tsx
@@ -296,15 +296,25 @@ export default function ToolbarPlugin({
     [activeEditor, $updateToolbarFromSelection]
   )
 
+  const setEditorEditable = useCallback(
+    (editable: boolean) => {
+      editor.setEditable(editable)
+      if (activeEditor !== editor) {
+        activeEditor.setEditable(editable)
+      }
+    },
+    [activeEditor, editor]
+  )
+
   const togglePreview = useCallback(() => {
-    activeEditor.setEditable(!isEditable)
-  }, [activeEditor, isEditable])
+    setEditorEditable(!isEditable)
+  }, [isEditable, setEditorEditable])
 
   const leavePreviewMode = useCallback(() => {
     if (!isEditable) {
-      activeEditor.setEditable(true)
+      setEditorEditable(true)
     }
-  }, [activeEditor, isEditable])
+  }, [isEditable, setEditorEditable])
 
   const onToggleFullscreen = useCallback(() => {
     if (isFullscreen) {

--- a/packages/lexical-editor/src/react/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-editor/src/react/plugins/ToolbarPlugin/index.tsx
@@ -669,6 +669,7 @@ export default function ToolbarPlugin({
           onToggleFullscreen={() => setIsFullscreen((current) => !current)}
         />
         <button
+          disabled={!isFullscreen}
           onClick={togglePreview}
           className={`toolbar-item spaced`}
           type="button"

--- a/packages/lexical-editor/src/react/plugins/ToolbarPlugin/index.tsx
+++ b/packages/lexical-editor/src/react/plugins/ToolbarPlugin/index.tsx
@@ -300,6 +300,19 @@ export default function ToolbarPlugin({
     activeEditor.setEditable(!isEditable)
   }, [activeEditor, isEditable])
 
+  const leavePreviewMode = useCallback(() => {
+    if (!isEditable) {
+      activeEditor.setEditable(true)
+    }
+  }, [activeEditor, isEditable])
+
+  const onToggleFullscreen = useCallback(() => {
+    if (isFullscreen) {
+      leavePreviewMode()
+    }
+    setIsFullscreen((current) => !current)
+  }, [isFullscreen, leavePreviewMode, setIsFullscreen])
+
   useEffect(() => {
     return editor.registerCommand(
       SELECTION_CHANGE_COMMAND,
@@ -666,7 +679,7 @@ export default function ToolbarPlugin({
         <Divider />
         <Fullscreen
           isFullscreen={isFullscreen}
-          onToggleFullscreen={() => setIsFullscreen((current) => !current)}
+          onToggleFullscreen={onToggleFullscreen}
         />
         <button
           disabled={!isFullscreen}


### PR DESCRIPTION
# Issue
- add specified class `editor-fullscreen-scroller` for storytelling components
- disable preview button when not in fullscreen

# Dependency
N/A
