### PR TITLE
fix(lexical-editor): restore sticky positioning for fullscreen embeds

### DIFF
--- a/packages/lexical-editor/src/react/plugins/ToolbarPlugin/Toolbar.scss
+++ b/packages/lexical-editor/src/react/plugins/ToolbarPlugin/Toolbar.scss
@@ -23,6 +23,13 @@
       padding-top: 36px;
     }
 
+    /* In fullscreen mode, allow `position: sticky` inside embedded code to work.
+     * Editor.scss sets `overflow-x: hidden` on `.lexical-content-editable`, which
+     * per CSS spec forces `overflow-y` from `visible` to `auto`, making it an
+     * unintended scroll container. That breaks `position: sticky` because sticky
+     * elements find this container instead of `.editor-shell.fullscreen`.
+     * Overriding with `overflow-x: visible` restores the default so no intermediate
+     * scroll container is created, and sticky correctly targets the fullscreen shell. */
     .lexical-content-editable {
       overflow-x: visible;
     }


### PR DESCRIPTION
 ## Summary

  Add documentation for the fullscreen sticky overflow override in lexical-editor.

  ## Context

  Fullscreen embeds rely on .editor-shell.fullscreen as the intended scroll container for position: sticky.
 The existing overflow-x: visible override on .lexical-content-editable is needed to prevent the editable area from becoming an unintended scroll container.

  ## Change

  Add an inline comment in Toolbar.scss explaining:

  - why overflow-x: hidden from Editor.scss can break sticky behavior
  - why the fullscreen override uses overflow-x: visible
  - how this preserves the fullscreen shell as the correct sticky scroll
    container

  ## Result

  The fullscreen sticky fix remains unchanged functionally, but the reason for the override is now documented in code for future maintenance.